### PR TITLE
Add Postgres 16 support by updating pgx/pgrx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,21 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg13"]
-pg11 = ["pgx/pg11", "pgx-tests/pg11" ]
-pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
-pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
-pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
-pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
+default = ["pg16"]
+pg11 = ["pgrx/pg11", "pgrx-tests/pg11" ]
+pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgx = { version = "0.7.3", features = [ "unsafe-postgres" ] }
+pgrx = { version = "0.10.1", features = [ "unsafe-postgres" ] }
 tiktoken-rs = { git = "https://github.com/kelvich/tiktoken-rs" }
 
 [dev-dependencies]
-pgx-tests = "0.7.3"
+pgrx-tests = "0.10.1"
 
 [profile.dev]
 panic = "unwind"

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Postgres extension that does input tokenization using OpenAI's tiktoken.
 db=> create extension pg_tiktoken;
 CREATE EXTENSION
 db=> select tiktoken_count('p50k_edit', 'A long time ago in a galaxy far, far away');
- tiktoken_count 
+ tiktoken_count
 ----------------
              11
 (1 row)
 
 db=> select tiktoken_encode('cl100k_base', 'A long time ago in a galaxy far, far away');
-                  tiktoken_encode                   
+                  tiktoken_encode
 ----------------------------------------------------
  {32,1317,892,4227,304,264,34261,3117,11,3117,3201}
 (1 row)
@@ -38,13 +38,13 @@ db=> select tiktoken_encode('cl100k_base', 'A long time ago in a galaxy far, far
 Assuming that rust toolchain is already istalled:
 
 ```sh
-# install pgx
-cargo install --locked cargo-pgx
-cargo pgx init
+# install pgrx
+cargo install --locked cargo-pgrx
+cargo pgrx init
 # build and install pg_tiktoken
 git clone https://github.com/kelvich/pg_tiktoken
 cd pg_tiktoken
-cargo pgx install
+cargo pgrx install
 ```
 
 ## Kudos

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use pgx::prelude::*;
+use pgrx::prelude::*;
 
 use tiktoken_rs::encoding_for_model;
 use tiktoken_rs::r50k_base;
@@ -6,7 +6,7 @@ use tiktoken_rs::cl100k_base;
 use tiktoken_rs::p50k_base;
 use tiktoken_rs::p50k_edit;
 
-pgx::pg_module_magic!();
+pgrx::pg_module_magic!();
 
 // encode to the array of tokens using given encoding/model
 //
@@ -47,7 +47,7 @@ fn tiktoken_count(encoding_selector: &str, text: &str) -> i64 {
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgx::prelude::*;
+    use pgrx::prelude::*;
 
     #[pg_test]
     fn test_tiktoken_encode() {
@@ -101,7 +101,7 @@ mod tests {
 
 }
 
-/// This module is required by `cargo pgx test` invocations. 
+/// This module is required by `cargo pgrx test` invocations.
 /// It must be visible at the root of your extension crate.
 #[cfg(test)]
 pub mod pg_test {


### PR DESCRIPTION
- `pgx` has been renamed to `pgrx`
- `pgrx` supports Postgres 16 since `0.10`

```
$ PG_VERSION=pg16 cargo pgrx test
       Using CliArgument("pg16") and `pg_config` from /Users/bayandin/.pgrx/16.0/pgrx-install/bin/pg_config
CARGO_TARGET_DIR="/Users/bayandin/work/pg_tiktoken/target" PGRX_ALL_FEATURES="false" PGRX_BUILD_PROFILE="dev" PGRX_FEATURES="pg16 pg_test" PGRX_NO_DEFAULT_FEATURES="true" PGRX_NO_SCHEMA="false" "/opt/homebrew/Cellar/rust/1.72.0_1/bin/cargo" "test" "--features" "pg16 pg_test" "--no-default-features"
   Compiling pgrx-pg-sys v0.10.1
   Compiling pgrx v0.10.1
   Compiling pgrx-tests v0.10.1
   Compiling pg_tiktoken v0.0.1 (/Users/bayandin/work/pg_tiktoken)
    Finished test [unoptimized + debuginfo] target(s) in 41.57s
     Running unittests src/lib.rs (target/debug/deps/pg_tiktoken-b3660b2f62b8bc2b)

running 2 tests
    Building extension with features pg_test pg16
     Running command "/opt/homebrew/Cellar/rust/1.72.0_1/bin/cargo" "build" "--features" "pg_test pg16" "--no-default-features" "--message-format=json-render-diagnostics"
  Installing extension
     Copying control file to /Users/bayandin/.pgrx/16.0/pgrx-install/share/postgresql/extension/pg_tiktoken.control
     Copying shared library to /Users/bayandin/.pgrx/16.0/pgrx-install/lib/postgresql/pg_tiktoken.dylib
    Finished installing pg_tiktoken
test tests::pg_test_tiktoken_count ... ok
test tests::pg_test_tiktoken_encode ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 38.14s

stopping postgres (pid=21366)
```